### PR TITLE
Adds a worker that checks for potential duplicated tickets

### DIFF
--- a/CcWorks/IssueLocation.cs
+++ b/CcWorks/IssueLocation.cs
@@ -1,0 +1,17 @@
+﻿using Atlassian.Jira;
+using Newtonsoft.Json;
+
+namespace CcWorks
+{
+    public class IssueLocation
+    {
+        [JsonProperty("fileName")]
+        public string FileName { get; set; }
+
+        [JsonProperty("startLine")]
+        public int StartLine { get; set; }
+
+        [JsonProperty("endLine")]
+        public int EndLine { get; set; }
+    }
+}

--- a/CcWorks/Program.cs
+++ b/CcWorks/Program.cs
@@ -51,7 +51,7 @@ namespace CcWorks
                             break;
 
                         case "new":
-                            await NewWorker.DoWork(settings.NewCommand, settings.CommonSettings, commandParameters, jira);
+                            await NewWorker.DoWork(settings.NewCommand, settings, commandParameters, jira);
                             break;
 
                         case "pr":

--- a/CcWorks/Program.cs
+++ b/CcWorks/Program.cs
@@ -78,6 +78,11 @@ namespace CcWorks
                             await SolveWorker.DoWork(settings.CommonSettings, commandParameters, jira);
                             break;
 
+                        case "ticket":
+                        case "ticketcheck":
+                            await DuplicateTicketChecker.DoWork(settings.DuplicateTicketCommand, commandParameters, jira);
+                            break;
+
                         case "exit":
                             return;
 

--- a/CcWorks/Settings.cs
+++ b/CcWorks/Settings.cs
@@ -12,6 +12,7 @@ namespace CcWorks
         public CiCommandSettings CiCommand { get; set; }
         public ReviewCommandSettings ReviewCommand { get; set; }
         public RebaseCommandSettings RebaseCommand { get; set; }
+        public DuplicateTicketCommandSettings DuplicateTicketCommand { get; set; }
     }
 
     public class CommonSettings
@@ -65,5 +66,11 @@ namespace CcWorks
 
     public class RebaseCommandSettings
     {
+    }
+
+    public class DuplicateTicketCommandSettings
+    {
+        public bool? CheckDuplicateForNew { get; set; }
+        public int LineOffset { get; set; } = 0;
     }
 }

--- a/CcWorks/Settings.cs
+++ b/CcWorks/Settings.cs
@@ -70,6 +70,7 @@ namespace CcWorks
 
     public class DuplicateTicketCommandSettings
     {
+        public bool? CheckSameTypeOnly { get; set; }
         public bool? CheckDuplicateForNew { get; set; }
         public int LineOffset { get; set; } = 0;
     }

--- a/CcWorks/Workers/DuplicateTicketChecker.cs
+++ b/CcWorks/Workers/DuplicateTicketChecker.cs
@@ -28,9 +28,9 @@ namespace CcWorks.Workers
             var ticketKey = JiraHelper.GetIssueKey(ticketUrl);
 
             bool sameTypeOnly;
-            if (settings.CheckDuplicateForNew.HasValue)
+            if (settings.CheckSameTypeOnly.HasValue)
             {
-                sameTypeOnly = settings.CheckDuplicateForNew.Value;
+                sameTypeOnly = settings.CheckSameTypeOnly.Value;
             }
             else
             {

--- a/CcWorks/Workers/DuplicateTicketChecker.cs
+++ b/CcWorks/Workers/DuplicateTicketChecker.cs
@@ -46,8 +46,8 @@ namespace CcWorks.Workers
 
             if (tickets.Any())
             {
-                Console.WriteLine("Here are the possible duplications:");
-                tickets.ForEach(issue => Console.WriteLine($"https://jira.devfactory.com/browse/{issue.Key}"));
+                ConsoleHelper.WriteColor("Here are the possible duplications:\n\n", ConsoleColor.DarkYellow);
+                tickets.ForEach(issue => ConsoleHelper.WriteColor($"https://jira.devfactory.com/browse/{issue.Key}\n", ConsoleColor.Yellow));
             }
             else
             {
@@ -84,17 +84,15 @@ namespace CcWorks.Workers
                         var overlap = locations.Any(
                             location => queryFiles.Any(
                                 issueLocation =>
-                                    issueLocation.FileName.Equals(
-                                        location.FileName,
-                                        StringComparison.OrdinalIgnoreCase)
+                                    issueLocation.FileName.Equals(location.FileName, StringComparison.OrdinalIgnoreCase)
                                     && (issueLocation.StartLine >= location.StartLine + settings.LineOffset
-                                        || issueLocation.StartLine >= location.StartLine - settings.LineOffset)
-                                    && (issueLocation.StartLine <= location.EndLine + settings.LineOffset
+                                        || issueLocation.StartLine >= location.StartLine - settings.LineOffset
+                                        || issueLocation.StartLine <= location.EndLine + settings.LineOffset
                                         || issueLocation.StartLine <= location.EndLine - settings.LineOffset)
                                     && (issueLocation.EndLine >= location.StartLine + settings.LineOffset
                                         || issueLocation.EndLine >= location.StartLine - settings.LineOffset)
-                                    && (issueLocation.EndLine <= location.EndLine + settings.LineOffset
-                                        || issueLocation.EndLine <= location.EndLine - settings.LineOffset)));
+                                    || issueLocation.EndLine <= location.EndLine + settings.LineOffset
+                                    || issueLocation.EndLine <= location.EndLine - settings.LineOffset));
                         return overlap;
                     })
                 .ToList();

--- a/CcWorks/Workers/DuplicateTicketChecker.cs
+++ b/CcWorks/Workers/DuplicateTicketChecker.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Atlassian.Jira;
+using CcWorks.Exceptions;
+using CcWorks.Helpers;
+using Newtonsoft.Json;
+
+namespace CcWorks.Workers
+{
+    public static class DuplicateTicketChecker
+    {
+        public static async Task DoWork(
+            DuplicateTicketCommandSettings settings,
+            Parameters parameters,
+            Jira jira)
+        {
+            if (parameters.Any())
+            {
+                throw new CcException("Command \"ticket\" doesn't support parameters yet");
+            }
+
+            var ticketUrl = parameters.Get("Enter ticket address: ");
+
+            var ticketKey = JiraHelper.GetIssueKey(ticketUrl);
+
+            bool sameTypeOnly;
+            if (settings.CheckDuplicateForNew.HasValue)
+            {
+                sameTypeOnly = settings.CheckDuplicateForNew.Value;
+            }
+            else
+            {
+                var considerOtherTicketsTypes = parameters.Get("Consider only tickets of same type? [Y/N] : ");
+                sameTypeOnly = string.IsNullOrWhiteSpace(considerOtherTicketsTypes)
+                    || considerOtherTicketsTypes.Equals("y", StringComparison.OrdinalIgnoreCase)
+                    || considerOtherTicketsTypes.Equals("yes", StringComparison.OrdinalIgnoreCase);
+            }
+
+            Console.WriteLine("Getting duplicate tickets report... ");
+            var tickets = await GetDuplicatedTickets(ticketKey, sameTypeOnly, jira, settings);
+
+
+            if (tickets.Any())
+            {
+                Console.WriteLine("Here are the possible duplications:");
+                tickets.ForEach(issue => Console.WriteLine($"https://jira.devfactory.com/browse/{issue.Key}"));
+            }
+            else
+            {
+                Console.WriteLine("No duplications found!");
+            }
+        }
+
+        public static async Task<List<Issue>> GetDuplicatedTickets(
+            string ticketKey,
+            bool sameTypeOnly,
+            Jira jira,
+            DuplicateTicketCommandSettings settings)
+        {
+            var issue = await jira.Issues.GetIssueAsync(ticketKey);
+
+            var queryFiles = GetIssueLocationsFromTicket(issue);
+
+            var fileQuery = new StringBuilder();
+
+            queryFiles.ForEach(
+                locations => { fileQuery.Append($@"and description ~""{locations.FileName}"" "); });
+
+            var openStatuses = @"AND status in (""in progress"", ""ready to refactor"", ""ready for review"", ""code review"", ""code merge"")";
+            var jql = $@"Project = CC {openStatuses} {fileQuery} Order By Updated DESC";
+            var issues = await jira.Issues.GetIssuesFromJqlAsync(jql) ;
+            return issues.Where(
+                    dup => issue.Key.Value != dup.Key.Value
+                        && issue.GetScmUrl() == dup.GetScmUrl()
+                        && (!sameTypeOnly || issue.Type.Name == dup.Type.Name))
+                .Where(
+                    dup =>
+                    {
+                        var locations = GetIssueLocationsFromTicket(dup);
+                        var overlap = locations.Any(
+                            location => queryFiles.Any(
+                                issueLocation =>
+                                    issueLocation.FileName.Equals(
+                                        location.FileName,
+                                        StringComparison.OrdinalIgnoreCase)
+                                    && (issueLocation.StartLine >= location.StartLine + settings.LineOffset
+                                        || issueLocation.StartLine >= location.StartLine - settings.LineOffset)
+                                    && (issueLocation.StartLine <= location.EndLine + settings.LineOffset
+                                        || issueLocation.StartLine <= location.EndLine - settings.LineOffset)
+                                    && (issueLocation.EndLine >= location.StartLine + settings.LineOffset
+                                        || issueLocation.EndLine >= location.StartLine - settings.LineOffset)
+                                    && (issueLocation.EndLine <= location.EndLine + settings.LineOffset
+                                        || issueLocation.EndLine <= location.EndLine - settings.LineOffset)));
+                        return overlap;
+                    })
+                .ToList();
+        }
+
+        private static List<IssueLocation> GetIssueLocationsFromTicket(Issue issue)
+        {
+            var fileRegex = new Regex(@"\[([^\]]+)\]");
+            var json = fileRegex.Match(issue.Description).Value;
+            return JsonConvert.DeserializeObject<List<IssueLocation>>(json);
+        }
+    }
+}

--- a/CcWorks/Workers/NewWorker.cs
+++ b/CcWorks/Workers/NewWorker.cs
@@ -94,12 +94,12 @@ namespace CcWorks.Workers
                 {
                     ConsoleHelper.WriteColor(
                         $"There are open tickets that overlap some of the code for the ticket you just created,\n"
-                        + $" please look into them to avoid conflicts and working on duplicated tickets.",
+                        + $" please look into them to avoid conflicts and working on duplicated tickets.\n\n",
                         ConsoleColor.DarkYellow);
 
                     duplicates.ForEach(
                         dupIssue => ConsoleHelper.WriteColor(
-                            $"https://jira.devfactory.com/browse/{dupIssue.Key}",
+                            $"https://jira.devfactory.com/browse/{dupIssue.Key}\n",
                             ConsoleColor.Yellow));
                 }
             }

--- a/CcWorks/Workers/NewWorker.cs
+++ b/CcWorks/Workers/NewWorker.cs
@@ -13,8 +13,11 @@ namespace CcWorks.Workers
 {
     public static class NewWorker
     {
-        public static async Task DoWork(NewCommandSettings settings, CommonSettings commonSettings, Parameters parameters, Jira jira)
+        public static async Task DoWork(NewCommandSettings settings, Settings allSettings, Parameters parameters, Jira jira)
         {
+            var commonSettings = allSettings.CommonSettings;
+            var duplicateTicketSettings = allSettings.DuplicateTicketCommand;
+
             if (parameters.Any())
             {
                 throw new CcException("Command \"new\" doesn't support parameters yet");
@@ -74,6 +77,32 @@ namespace CcWorks.Workers
             }
 
             Console.WriteLine($"New issue: https://jira.devfactory.com/browse/{newIssue.Key}");
+
+            var checkDuplicateTicket = duplicateTicketSettings.CheckDuplicateForNew.HasValue
+                && duplicateTicketSettings.CheckDuplicateForNew.Value;
+
+            if (checkDuplicateTicket)
+            {
+                var checkSameTypeOnly = duplicateTicketSettings.CheckSameTypeOnly.HasValue && duplicateTicketSettings.CheckSameTypeOnly.Value;
+                var duplicates = await DuplicateTicketChecker.GetDuplicatedTickets(
+                    newIssue.Key.Value,
+                    checkSameTypeOnly,
+                    jira,
+                    duplicateTicketSettings);
+
+                if (duplicates.Any())
+                {
+                    ConsoleHelper.WriteColor(
+                        $"There are open tickets that overlap some of the code for the ticket you just created,\n"
+                        + $" please look into them to avoid conflicts and working on duplicated tickets.",
+                        ConsoleColor.DarkYellow);
+
+                    duplicates.ForEach(
+                        dupIssue => ConsoleHelper.WriteColor(
+                            $"https://jira.devfactory.com/browse/{dupIssue.Key}",
+                            ConsoleColor.Yellow));
+                }
+            }
         }
 
         private static List<FilePart> ReadFileParts(string longTicketType)

--- a/CcWorks/settings.json
+++ b/CcWorks/settings.json
@@ -75,5 +75,11 @@
     "reviewCommand": {
         // Assign PR to you after moving to review
         "assignPr": true
+    },
+    "DuplicateTicketCommand": {
+        // Offset to consider when checking overlaping of lines
+        "lineoffset": 0,
+        // Look only at tickets for the same type, true, false or empty to ask every time 
+        "CheckDuplicateForNew": ""
     }
 }

--- a/CcWorks/settings.json
+++ b/CcWorks/settings.json
@@ -80,6 +80,8 @@
         // Offset to consider when checking overlaping of lines
         "lineoffset": 0,
         // Look only at tickets for the same type, true, false or empty to ask every time 
+        "CheckSameTypeOnly": "",
+        // Look only at tickets for the same type, true, false or empty to ask every time 
         "CheckDuplicateForNew": ""
     }
 }


### PR DESCRIPTION
# Changes

Creates a new worker that looks for potentially duplicate tickets.

The current logic of checking is very broad, it looks for any ticket that contain an overlap (same file and line range), basically considering as potential duplicates any ticket that will touch the same portion of any of the files inside the ticket description.